### PR TITLE
Fix the examples showcasing the usage of the `featureFlagElse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![CI](https://github.com/pBouillon/ngx-flagr/actions/workflows/ci.yml/badge.svg)](https://github.com/pBouillon/ngx-flagr/actions/workflows/ci.yml) [![GitHub discussions](https://img.shields.io/github/discussions/pbouillon/ngx-flagr?logo=github)](https://github.com/pbouillon/ngx-flagr/discussions) [![npm](https://img.shields.io/npm/v/@ngx-flagr/core.svg)](https://www.npmjs.com/package/@ngx-flagr/core) [![npm](https://img.shields.io/npm/dt/@ngx-flagr/core)](https://www.npmjs.com/package/@ngx-flagr/core)
 
-
-> 🚩 Effortless feature flag management in Angular 
+> 🚩 Effortless feature flag management in Angular
 
 With `ngx-flagr`, you can easily manage feature flags, target specific users or segments, and experiment with different variations of your app's features.
 
@@ -94,7 +93,7 @@ The `featureFlag` directive takes a `FeatureFlag` for input that is either a `st
 ##### With a fallback
 
 ```html
-<div *featureFlag="'my-feature'">
+<div *featureFlag="'my-feature'; else disabledContent">
   This content will only be rendered if the 'my-feature' feature flag is enabled.
 </div>
 

--- a/projects/core/src/feature-flag.directive.ts
+++ b/projects/core/src/feature-flag.directive.ts
@@ -46,7 +46,7 @@ import { FEATURE_FLAG_SERVICE } from './tokens';
  * ### With a fallback
  *
  * ```html
- * <div *featureFlag="'my-feature'">
+ * <div *featureFlag="'my-feature'; else disabledContent">
  *   This content will only be rendered if the 'my-feature' feature flag is enabled.
  * </div>
  *


### PR DESCRIPTION
## Pull Request Description

This issues fix the incorrect usage of the `featureFlagElse` showcased in the docs.

## Related Issue

Closes #8 

## Changes Made

> [Describe the changes you've made.]

## Checklist

- [x] I have updated the documentation.

## Additional Information

N/A
