### PR TITLE
3 add a guard based on the feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Feature
+
+- **core:** create a functional guard `canMatchFeatureFlag`
+- **core:** add the configuration of the `canMatchFeatureFlag` behavior to the `NgxFlagrConfiguration`
+- **core:** update the usage of `provideNgxConfiguration` to include a default `routing` section
+
+### Others
+
+- **core:** move the definition of the `FeatureFlag` type into its own file
+- **core:** add a method to evaluate if a value is a `FeatureFlag`
+- **core:** add tests for the `provideNgxConfiguration` method
+
 ## [0.1.0] - (2023-04-16)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ With `ngx-flagr`, you can easily manage feature flags, target specific users or 
   - [Register the service](#register-the-service)
 - [Usage](#usage)
   - [`featureFlag` directive](#featureflag-directive)
-    - [Examples](#examples)
-      - [With a single flag](#with-a-single-flag)
-      - [With multiple flags](#with-multiple-flags)
-      - [With a fallback](#with-a-fallback)
+    - [With a single flag](#with-a-single-flag)
+    - [With multiple flags](#with-multiple-flags)
+    - [With a fallback](#with-a-fallback)
 - [License](#license)
 
 ## Installation
@@ -72,9 +71,7 @@ bootstrapApplication(AppComponent, {
 
 The `featureFlag` directive takes a `FeatureFlag` for input that is either a `string` or a `string[]`. It then conditionally renders the content of your template based on the evaluation of the parameter by the provided `FeatureFlagService`.
 
-#### Examples
-
-##### With a single flag
+#### With a single flag
 
 ```html
 <div *featureFlag="'my-feature'">
@@ -82,7 +79,7 @@ The `featureFlag` directive takes a `FeatureFlag` for input that is either a `st
 </div>
 ```
 
-##### With multiple flags
+#### With multiple flags
 
 ```html
 <div *featureFlag="['my', 'feature']">
@@ -90,7 +87,7 @@ The `featureFlag` directive takes a `FeatureFlag` for input that is either a `st
 </div>
 ```
 
-##### With a fallback
+#### With a fallback
 
 ```html
 <div *featureFlag="'my-feature'; else disabledContent">

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ With `ngx-flagr`, you can easily manage feature flags, target specific users or 
     - [With a single flag](#with-a-single-flag)
     - [With multiple flags](#with-multiple-flags)
     - [With a fallback](#with-a-fallback)
+  - [The `canMatchFeatureFlag` functional guard](#the-canmatchfeatureflag-functional-guard)
+    - [Configuration](#configuration)
+    - [With feature flags](#with-feature-flags)
+    - [With a fallback route](#with-a-fallback-route)
+    - [With a passthrough](#with-a-passthrough)
+    - [With a global redirection target](#with-a-global-redirection-target)
 - [License](#license)
 
 ## Installation
@@ -97,6 +103,120 @@ The `featureFlag` directive takes a `FeatureFlag` for input that is either a `st
 <ng-template #disabledContent>
   This content will be rendered when the 'my-feature' feature flag is disabled.
 </ng-template>
+```
+
+### The `canMatchFeatureFlag` functional guard
+
+`ngx-flagr` also provides a functional guard to control your routes resolution.
+
+When used, it will check for the feature flags provided on the route level and
+will evaluate whether they are enabled or not based on your implementation of
+the `FeatureFlagService`.
+
+Behavior can be configured within `provideNgxFlagr`.
+
+#### Configuration
+
+Several options are available to configure the desired behavior of the guard:
+
+```ts
+provideNgxFlagr({
+  // ...
+
+  // Optional configuration section
+  routing: {
+    // The keys used to retrieve values in the `data` section of the `Route`
+    keys: {
+      // The key where the feature flags will be defined
+      featureFlag: 'featureFlag',
+      // The key to the route the user will be redirected to if the guard
+      // resolution fails
+      redirectToIfDisabled: 'redirectToIfDisabled',
+    },
+
+    // The default redirection if the guard fails and no other route is defined
+    // at the route-level
+    redirectToIfDisabled: null,
+    // Whether the guard should let pass through routes that invokes it but
+    // without providing feature flags
+    validIfNone: false,
+  },
+});
+```
+
+On your routes, simply provide the guard in the `canMatch` array.
+
+#### With feature flags
+
+```ts
+const routes: Route[] = [
+  {
+    path: 'fast-delivery',
+    component: FastDeliveryComponent,
+    canMatch: canMatchFeatureFlag,
+    data: { featureFlag: 'fast-delivery' }
+  },
+];
+```
+
+#### With a fallback route
+
+```ts
+const routes: Route[] = [
+  {
+    path: 'fast-delivery',
+    component: FastDeliveryComponent,
+    canMatch: canMatchFeatureFlag,
+    data: {
+      featureFlags: 'fast-delivery',
+      redirectToIfDisabled: 'delivery',
+    }
+  },
+];
+```
+
+#### As a passthrough when no flags are provided
+
+```ts
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideNgxFlagr({
+      featureFlagService: CustomFeatureFlagService,
+      routing: { validIfNone: true }
+    })
+  ],
+});
+
+const routes: Route[] = [
+  {
+    path: 'fast-delivery',
+    component: FastDeliveryComponent,
+    canMatch: canMatchFeatureFlag,
+    data: { }
+  },
+];
+```
+
+#### With a global redirection target
+
+```ts
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideNgxFlagr({
+      featureFlagService: CustomFeatureFlagService,
+      routing: { redirectToIfDisabled: 'unauthorized' }
+    })
+  ],
+});
+
+const routes: Route[] = [
+  {
+    path: 'fast-delivery',
+    component: FastDeliveryComponent,
+    canMatch: canMatchFeatureFlag,
+    data: { featureFlag: 'fast-delivery' }
+  },
+];
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@angular/common": "^15.2.0",
         "@angular/compiler": "^15.2.0",
         "@angular/core": "^15.2.0",
-        "@angular/forms": "^15.2.0",
         "@angular/platform-browser": "^15.2.0",
         "@angular/platform-browser-dynamic": "^15.2.0",
         "@angular/router": "^15.2.0",
@@ -616,23 +615,6 @@
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.11.4 || ~0.12.0 || ~0.13.0"
-      }
-    },
-    "node_modules/@angular/forms": {
-      "version": "15.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-15.2.7.tgz",
-      "integrity": "sha512-rzrebDIrtxxOeMcBzRBxqaOBZ+T1DJrysG/6YWZy428W/Z3MfPxUarPxgfx/oZI+x5uUsDaZmyoRdhVPJ2KhZg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "15.2.7",
-        "@angular/core": "15.2.7",
-        "@angular/platform-browser": "15.2.7",
-        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@angular/core": "^15.2.0",
     "@angular/platform-browser": "^15.2.0",
     "@angular/platform-browser-dynamic": "^15.2.0",
+    "@angular/router": "^15.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.12.0"

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/pbouillon/ngx-flagr#readme",
   "peerDependencies": {
     "@angular/common": "^15.2.0",
-    "@angular/core": "^15.2.0"
+    "@angular/core": "^15.2.0",
+    "@angular/router": "^15.2.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngx-flagr/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An Angular library providing directives, services and more to ease the usage of feature flags in Angular",
   "keywords": [
     "Angular",

--- a/projects/core/src/config.spec.ts
+++ b/projects/core/src/config.spec.ts
@@ -1,0 +1,76 @@
+import { createConfiguration, NgxFlagrOptions } from './config';
+import { FeatureFlagService } from './feature-flag.service';
+
+class TestService implements FeatureFlagService {
+  isEnabled(): boolean {
+    return false;
+  }
+}
+
+describe('createConfiguration', () => {
+  let options: NgxFlagrOptions;
+
+  it('creates default options with only a feature flag service', () => {
+    options = {
+      featureFlagService: TestService,
+    };
+
+    expect(createConfiguration(options)).toEqual({
+      featureFlagService: TestService,
+      routing: {
+        keys: {
+          featureFlag: 'featureFlag',
+          redirectToIfDisabled: 'redirectToIfDisabled',
+        },
+        redirectToIfDisabled: null,
+        validIfNone: false,
+      },
+    });
+  });
+
+  it('creates default options with only a factory for the feature flag service', () => {
+    const factory = () => TestService;
+
+    options = {
+      featureFlagService: factory,
+    };
+
+    expect(createConfiguration(options)).toEqual({
+      featureFlagService: factory,
+      routing: {
+        keys: {
+          featureFlag: 'featureFlag',
+          redirectToIfDisabled: 'redirectToIfDisabled',
+        },
+        redirectToIfDisabled: null,
+        validIfNone: false,
+      },
+    });
+  });
+
+  it('creates options that contain passed in options', () => {
+    options = {
+      featureFlagService: TestService,
+      routing: {
+        keys: {
+          featureFlag: 'featureFlag-key',
+          redirectToIfDisabled: 'unauthorized-key',
+        },
+        redirectToIfDisabled: 'unauthorized',
+        validIfNone: true,
+      },
+    };
+
+    expect(createConfiguration(options)).toEqual({
+      featureFlagService: TestService,
+      routing: {
+        keys: {
+          featureFlag: 'featureFlag-key',
+          redirectToIfDisabled: 'unauthorized-key',
+        },
+        redirectToIfDisabled: 'unauthorized',
+        validIfNone: true,
+      },
+    });
+  });
+});

--- a/projects/core/src/config.ts
+++ b/projects/core/src/config.ts
@@ -3,9 +3,29 @@ import { Type } from '@angular/core';
 import { FeatureFlagService } from './feature-flag.service';
 
 export interface NgxFlagrConfiguration {
+  /**
+   * The {@link FeatureFlagService} used to evaluate feature flags.
+   *
+   * @remarks
+   * This property can either be a reference to a class implementing the
+   * {@link FeatureFlagService} interface, or a function that returns a
+   * reference to such a class.
+   */
   featureFlagService:
     | Type<FeatureFlagService>
     | (() => Type<FeatureFlagService>);
+
+  /**
+   * The key used to identify feature flags in the `data` property of Angular
+   * routes.
+   *
+   * @default 'featureFlag'
+   *
+   * @remarks
+   * This property is used to identify which property in the `data` object of an
+   * Angular route contains the feature flag for that route.
+   */
+  routeDataFeatureFlagKey: string;
 }
 
 export type NgxFlagrPartialConfig = Partial<NgxFlagrConfiguration> &
@@ -21,7 +41,9 @@ export function createConfiguration(
   const DEFAULT_CONFIGURATION: Omit<
     NgxFlagrConfiguration,
     'featureFlagService'
-  > = {};
+  > = {
+    routeDataFeatureFlagKey: 'featureFlag',
+  };
 
   const options =
     typeof optionsInput === 'function' ? optionsInput() : optionsInput;

--- a/projects/core/src/config.ts
+++ b/projects/core/src/config.ts
@@ -15,17 +15,19 @@ export interface NgxFlagrConfiguration {
     | Type<FeatureFlagService>
     | (() => Type<FeatureFlagService>);
 
-  /**
-   * The key used to identify feature flags in the `data` property of Angular
-   * routes.
-   *
-   * @default 'featureFlag'
-   *
-   * @remarks
-   * This property is used to identify which property in the `data` object of an
-   * Angular route contains the feature flag for that route.
-   */
-  routeDataFeatureFlagKey: string;
+  routing: {
+    /**
+     * The key used to identify feature flags in the `data` property of Angular
+     * routes.
+     *
+     * @default 'featureFlag'
+     *
+     * @remarks
+     * This property is used to identify which property in the `data` object of an
+     * Angular route contains the feature flag for that route.
+     */
+    featureFlagKey: string;
+  };
 }
 
 export type NgxFlagrPartialConfig = Partial<NgxFlagrConfiguration> &
@@ -42,7 +44,9 @@ export function createConfiguration(
     NgxFlagrConfiguration,
     'featureFlagService'
   > = {
-    routeDataFeatureFlagKey: 'featureFlag',
+    routing: {
+      featureFlagKey: 'featureFlag',
+    },
   };
 
   const options =

--- a/projects/core/src/config.ts
+++ b/projects/core/src/config.ts
@@ -15,6 +15,9 @@ export interface NgxFlagrConfiguration {
     | Type<FeatureFlagService>
     | (() => Type<FeatureFlagService>);
 
+  /**
+   * Routing options for feature flags.
+   */
   routing: {
     /**
      * The key used to identify feature flags in the `data` property of Angular
@@ -26,7 +29,20 @@ export interface NgxFlagrConfiguration {
      * This property is used to identify which property in the `data` object of an
      * Angular route contains the feature flag for that route.
      */
-    featureFlagKey: string;
+    key: string;
+
+    /**
+     * The name of a route to redirect to if the user does not have the feature
+     * flag enabled.
+     *
+     * @default null
+     *
+     * @remarks
+     * If this property is set, and the feature flag for a route is disabled,
+     * the user will be redirected to the route with this name. If it is not
+     * set, the user will be denied access to the route.
+     */
+    redirectToIfDisabled: string | null;
 
     /**
      * The value returned by the guard when no feature flags are defined for a route.
@@ -57,7 +73,8 @@ export function createConfiguration(
     'featureFlagService'
   > = {
     routing: {
-      featureFlagKey: 'featureFlag',
+      key: 'featureFlag',
+      redirectToIfDisabled: null,
       validIfNone: false,
     },
   };

--- a/projects/core/src/config.ts
+++ b/projects/core/src/config.ts
@@ -27,6 +27,18 @@ export interface NgxFlagrConfiguration {
      * Angular route contains the feature flag for that route.
      */
     featureFlagKey: string;
+
+    /**
+     * The value returned by the guard when no feature flags are defined for a route.
+     *
+     * @default false
+     *
+     * @remarks
+     * If this property is set to `true`, the guard will allow access to routes that don't have any
+     * feature flags defined in their `data` property. If set to `false`, the guard will deny access to
+     * such routes.
+     */
+    validIfNone: boolean;
   };
 }
 
@@ -46,6 +58,7 @@ export function createConfiguration(
   > = {
     routing: {
       featureFlagKey: 'featureFlag',
+      validIfNone: false,
     },
   };
 

--- a/projects/core/src/config.ts
+++ b/projects/core/src/config.ts
@@ -19,17 +19,23 @@ export interface NgxFlagrConfiguration {
    * Routing options for feature flags.
    */
   routing: {
-    /**
-     * The key used to identify feature flags in the `data` property of Angular
-     * routes.
-     *
-     * @default 'featureFlag'
-     *
-     * @remarks
-     * This property is used to identify which property in the `data` object of an
-     * Angular route contains the feature flag for that route.
-     */
-    key: string;
+    keys: {
+      /**
+       * The key used to identify feature flags in the `data` property of Angular
+       * routes.
+       *
+       * @default 'featureFlag'
+       */
+      featureFlag: string;
+
+      /**
+       * The key used to identify the route to which the user will be redirected
+       * in the `data` property of Angular routes.
+       *
+       * @default 'redirectToIfDisabled'
+       */
+      redirectToIfDisabled: string;
+    };
 
     /**
      * The name of a route to redirect to if the user does not have the feature
@@ -73,7 +79,10 @@ export function createConfiguration(
     'featureFlagService'
   > = {
     routing: {
-      key: 'featureFlag',
+      keys: {
+        featureFlag: 'featureFlag',
+        redirectToIfDisabled: 'redirectToIfDisabled',
+      },
       redirectToIfDisabled: null,
       validIfNone: false,
     },

--- a/projects/core/src/feature-flag.can-match.guard.spec.ts
+++ b/projects/core/src/feature-flag.can-match.guard.spec.ts
@@ -1,0 +1,175 @@
+import { TestBed } from '@angular/core/testing';
+import { UrlTree } from '@angular/router';
+
+import { canMatchFeatureFlag } from './feature-flag.can-match.guard';
+import { FeatureFlagService } from './feature-flag.service';
+import { CONFIGURATION, FEATURE_FLAG_SERVICE } from './tokens';
+
+describe('canMatchFeatureFlag', () => {
+  let featureFlagServiceMock: jasmine.SpyObj<FeatureFlagService>;
+
+  beforeEach(() => {
+    featureFlagServiceMock = jasmine.createSpyObj<FeatureFlagService>(
+      'FeatureFlagService',
+      ['isEnabled']
+    );
+  });
+
+  it('reject navigation if the feature flag is not enabled', () => {
+    featureFlagServiceMock.isEnabled.and.returnValue(false);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: FEATURE_FLAG_SERVICE, useValue: featureFlagServiceMock },
+        {
+          provide: CONFIGURATION,
+          useValue: {
+            routing: {
+              keys: { featureFlag: 'featureFlag' },
+            },
+          },
+        },
+      ],
+    }).runInInjectionContext(() => {
+      const result = canMatchFeatureFlag(
+        { data: { featureFlag: 'not-valid' } },
+        []
+      );
+
+      expect(result).toBeFalse();
+    });
+  });
+
+  it('reject navigation if no feature flag is provided', () => {
+    featureFlagServiceMock.isEnabled.and.returnValue(false);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: FEATURE_FLAG_SERVICE, useValue: featureFlagServiceMock },
+        {
+          provide: CONFIGURATION,
+          useValue: {
+            routing: {
+              keys: { featureFlag: 'featureFlag' },
+              validIfNone: false,
+            },
+          },
+        },
+      ],
+    }).runInInjectionContext(() => {
+      const result = canMatchFeatureFlag({ data: {} }, []);
+
+      expect(result).toBeFalse();
+    });
+  });
+
+  it('accept navigation if no feature flag is provided and the flag is set', () => {
+    featureFlagServiceMock.isEnabled.and.returnValue(false);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: FEATURE_FLAG_SERVICE, useValue: featureFlagServiceMock },
+        {
+          provide: CONFIGURATION,
+          useValue: {
+            routing: {
+              keys: { featureFlag: 'featureFlag' },
+              validIfNone: true,
+            },
+          },
+        },
+      ],
+    }).runInInjectionContext(() => {
+      const result = canMatchFeatureFlag({ data: {} }, []);
+
+      expect(result).toBeTrue();
+    });
+  });
+
+  it('accept navigation if the feature flag is enable', () => {
+    featureFlagServiceMock.isEnabled.and.returnValue(true);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: FEATURE_FLAG_SERVICE, useValue: featureFlagServiceMock },
+        {
+          provide: CONFIGURATION,
+          useValue: {
+            routing: {
+              keys: { featureFlag: 'featureFlag' },
+            },
+          },
+        },
+      ],
+    }).runInInjectionContext(() => {
+      const result = canMatchFeatureFlag(
+        { data: { featureFlag: 'valid' } },
+        []
+      );
+
+      expect(result).toBeTrue();
+    });
+  });
+
+  it('reject and redirect navigation if the feature flag is disabled', () => {
+    featureFlagServiceMock.isEnabled.and.returnValue(false);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: FEATURE_FLAG_SERVICE, useValue: featureFlagServiceMock },
+        {
+          provide: CONFIGURATION,
+          useValue: {
+            routing: {
+              keys: { featureFlag: 'featureFlag' },
+              redirectToIfDisabled: 'rejected',
+            },
+          },
+        },
+      ],
+    }).runInInjectionContext(() => {
+      const result = canMatchFeatureFlag(
+        { data: { featureFlag: 'invalid' } },
+        []
+      );
+
+      expect(result).toBeInstanceOf(UrlTree);
+      expect(result.toString()).toBe('/rejected');
+    });
+  });
+
+  it('reject and redirect navigation to the route-level route if the feature flag is disabled', () => {
+    featureFlagServiceMock.isEnabled.and.returnValue(false);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: FEATURE_FLAG_SERVICE, useValue: featureFlagServiceMock },
+        {
+          provide: CONFIGURATION,
+          useValue: {
+            routing: {
+              keys: {
+                featureFlag: 'featureFlag',
+                redirectToIfDisabled: 'redirectToIfDisabled',
+              },
+              redirectToIfDisabled: 'rejected',
+            },
+          },
+        },
+      ],
+    }).runInInjectionContext(() => {
+      const result = canMatchFeatureFlag(
+        {
+          data: {
+            featureFlag: 'invalid',
+            redirectToIfDisabled: 'rejected-specific',
+          },
+        },
+        []
+      );
+
+      expect(result).toBeInstanceOf(UrlTree);
+      expect(result.toString()).toBe('/rejected-specific');
+    });
+  });
+});

--- a/projects/core/src/feature-flag.can-match.guard.spec.ts
+++ b/projects/core/src/feature-flag.can-match.guard.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { UrlTree } from '@angular/router';
+import { Route, UrlTree } from '@angular/router';
 
 import { canMatchFeatureFlag } from './feature-flag.can-match.guard';
 import { FeatureFlagService } from './feature-flag.service';
@@ -13,6 +13,27 @@ describe('canMatchFeatureFlag', () => {
       'FeatureFlagService',
       ['isEnabled']
     );
+  });
+
+  it('reject invalid feature flags', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: FEATURE_FLAG_SERVICE, useValue: featureFlagServiceMock },
+        {
+          provide: CONFIGURATION,
+          useValue: {
+            routing: {
+              keys: { featureFlag: 'featureFlag' },
+            },
+          },
+        },
+      ],
+    }).runInInjectionContext(() => {
+      const route: Route = { path: 'my-route', data: { featureFlag: 1337 } };
+      expect(() => canMatchFeatureFlag(route, [])).toThrowError(
+        'Route my-route has an invalid feature flag: 1337'
+      );
+    });
   });
 
   it('reject navigation if the feature flag is not enabled', () => {

--- a/projects/core/src/feature-flag.can-match.guard.ts
+++ b/projects/core/src/feature-flag.can-match.guard.ts
@@ -27,8 +27,8 @@ export const canMatchFeatureFlag: CanMatchFn = (
   | UrlTree => {
   const { routing } = inject(CONFIGURATION);
 
-  const { key } = routing;
-  const featureFlag = route.data?.[key];
+  const { keys } = routing;
+  const featureFlag = route.data?.[keys.featureFlag];
 
   if (!featureFlag) {
     const { validIfNone } = routing;
@@ -49,8 +49,12 @@ export const canMatchFeatureFlag: CanMatchFn = (
 
   const isEnabled = inject(FEATURE_FLAG_SERVICE).isEnabled(featureFlag);
 
-  const { redirectToIfDisabled } = routing;
-  if (redirectToIfDisabled === null) {
+  // Takes the redirection URL defined on the route level or on the
+  // configuration-level
+  let redirectToIfDisabled =
+    route.data?.[keys.redirectToIfDisabled] || routing.redirectToIfDisabled;
+
+  if (!redirectToIfDisabled) {
     return isEnabled;
   }
 

--- a/projects/core/src/feature-flag.can-match.guard.ts
+++ b/projects/core/src/feature-flag.can-match.guard.ts
@@ -1,0 +1,31 @@
+import { inject } from '@angular/core';
+import { CanMatchFn, Route, UrlTree } from '@angular/router';
+
+import { Observable } from 'rxjs';
+
+import { isFeatureFlag } from './feature-flag';
+import { FEATURE_FLAG_SERVICE } from './tokens';
+
+export const canMatchFeatureFlag: CanMatchFn = (
+  route: Route
+):
+  | Observable<boolean | UrlTree>
+  | Promise<boolean | UrlTree>
+  | boolean
+  | UrlTree => {
+  const featureFlag = route.data?.['featureFlag'];
+
+  if (!featureFlag) {
+    console.error(`Route ${route.path} does not have a feature flag specified`);
+    return false;
+  }
+
+  if (!isFeatureFlag(featureFlag)) {
+    console.error(
+      `Route ${route.path} has an invalid feature flag: ${featureFlag}`
+    );
+    return false;
+  }
+
+  return inject(FEATURE_FLAG_SERVICE).isEnabled(featureFlag);
+};

--- a/projects/core/src/feature-flag.can-match.guard.ts
+++ b/projects/core/src/feature-flag.can-match.guard.ts
@@ -4,7 +4,7 @@ import { CanMatchFn, Route, UrlTree } from '@angular/router';
 import { Observable } from 'rxjs';
 
 import { isFeatureFlag } from './feature-flag';
-import { FEATURE_FLAG_SERVICE } from './tokens';
+import { CONFIGURATION, FEATURE_FLAG_SERVICE } from './tokens';
 
 export const canMatchFeatureFlag: CanMatchFn = (
   route: Route
@@ -13,7 +13,8 @@ export const canMatchFeatureFlag: CanMatchFn = (
   | Promise<boolean | UrlTree>
   | boolean
   | UrlTree => {
-  const featureFlag = route.data?.['featureFlag'];
+  const { routeDataFeatureFlagKey } = inject(CONFIGURATION);
+  const featureFlag = route.data?.[routeDataFeatureFlagKey];
 
   if (!featureFlag) {
     console.error(`Route ${route.path} does not have a feature flag specified`);
@@ -24,6 +25,7 @@ export const canMatchFeatureFlag: CanMatchFn = (
     console.error(
       `Route ${route.path} has an invalid feature flag: ${featureFlag}`
     );
+    // TODO - Configure behavior
     return false;
   }
 

--- a/projects/core/src/feature-flag.can-match.guard.ts
+++ b/projects/core/src/feature-flag.can-match.guard.ts
@@ -13,8 +13,11 @@ export const canMatchFeatureFlag: CanMatchFn = (
   | Promise<boolean | UrlTree>
   | boolean
   | UrlTree => {
-  const { routeDataFeatureFlagKey } = inject(CONFIGURATION);
-  const featureFlag = route.data?.[routeDataFeatureFlagKey];
+  const {
+    routing: { featureFlagKey },
+  } = inject(CONFIGURATION);
+
+  const featureFlag = route.data?.[featureFlagKey];
 
   if (!featureFlag) {
     console.error(`Route ${route.path} does not have a feature flag specified`);
@@ -22,11 +25,9 @@ export const canMatchFeatureFlag: CanMatchFn = (
   }
 
   if (!isFeatureFlag(featureFlag)) {
-    console.error(
+    throw new Error(
       `Route ${route.path} has an invalid feature flag: ${featureFlag}`
     );
-    // TODO - Configure behavior
-    return false;
   }
 
   return inject(FEATURE_FLAG_SERVICE).isEnabled(featureFlag);

--- a/projects/core/src/feature-flag.directive.spec.ts
+++ b/projects/core/src/feature-flag.directive.spec.ts
@@ -52,7 +52,7 @@ describe(FeatureFlagDirective.name, () => {
   });
 
   describe('OnInit', () => {
-    it('should throw an error if featureFlag is not provided', async () => {
+    it('throw an error if featureFlag is not provided', async () => {
       fixture.componentInstance.flag = undefined;
 
       const directive: FeatureFlagDirective = fixture.debugElement
@@ -67,7 +67,7 @@ describe(FeatureFlagDirective.name, () => {
       );
     });
 
-    it('should not throw an error if featureFlag is provided as a string', async () => {
+    it('not throw an error if featureFlag is provided as a string', async () => {
       fixture.componentInstance.flag = 'some flag';
 
       const directive: FeatureFlagDirective = fixture.debugElement
@@ -83,7 +83,7 @@ describe(FeatureFlagDirective.name, () => {
         });
     });
 
-    it('should throw an error if featureFlag is an empty array', async () => {
+    it('throw an error if featureFlag is an empty array', async () => {
       fixture.componentInstance.flag = [];
 
       const directive: FeatureFlagDirective = fixture.debugElement
@@ -98,7 +98,7 @@ describe(FeatureFlagDirective.name, () => {
       );
     });
 
-    it('should not throw an error if featureFlag is a non-empty array', async () => {
+    it('not throw an error if featureFlag is a non-empty array', async () => {
       fixture.componentInstance.flag = ['some', 'flag'];
 
       const directive: FeatureFlagDirective = fixture.debugElement
@@ -117,7 +117,7 @@ describe(FeatureFlagDirective.name, () => {
 
   describe('Feature flag enabled', () => {
     describe('with boolean', () => {
-      it('should render the feature template', async () => {
+      it('render the feature template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(true);
 
         fixture.detectChanges();
@@ -129,7 +129,7 @@ describe(FeatureFlagDirective.name, () => {
         expect(featureEnabledElement).toBeTruthy();
       });
 
-      it('should not render the fallback template', async () => {
+      it('not render the fallback template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(true);
 
         fixture.detectChanges();
@@ -143,7 +143,7 @@ describe(FeatureFlagDirective.name, () => {
     });
 
     describe('with Promise<bool>', () => {
-      it('should render the feature template if the feature flag is enabled', async () => {
+      it('render the feature template if the feature flag is enabled', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(Promise.resolve(true));
 
         fixture.detectChanges();
@@ -155,7 +155,7 @@ describe(FeatureFlagDirective.name, () => {
         expect(featureEnabledElement).toBeTruthy();
       });
 
-      it('should not render the fallback template', async () => {
+      it('not render the fallback template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(Promise.resolve(true));
 
         fixture.detectChanges();
@@ -169,7 +169,7 @@ describe(FeatureFlagDirective.name, () => {
     });
 
     describe('with Observable<boolean>', () => {
-      it('should render the feature template if the feature flag is enabled', async () => {
+      it('render the feature template if the feature flag is enabled', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(of(true));
 
         fixture.detectChanges();
@@ -181,7 +181,7 @@ describe(FeatureFlagDirective.name, () => {
         expect(featureEnabledElement).toBeTruthy();
       });
 
-      it('should not render the fallback template', async () => {
+      it('not render the fallback template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(of(true));
 
         fixture.detectChanges();
@@ -197,7 +197,7 @@ describe(FeatureFlagDirective.name, () => {
 
   describe('Feature flag disabled', () => {
     describe('with boolean', () => {
-      it('should not render the feature template', async () => {
+      it('not render the feature template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(false);
 
         fixture.detectChanges();
@@ -209,7 +209,7 @@ describe(FeatureFlagDirective.name, () => {
         expect(featureEnabledElement).toBeFalsy();
       });
 
-      it('should render the fallback template', async () => {
+      it('render the fallback template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(false);
 
         fixture.detectChanges();
@@ -223,7 +223,7 @@ describe(FeatureFlagDirective.name, () => {
     });
 
     describe('with Promise<bool>', () => {
-      it('should not render the feature template', async () => {
+      it('not render the feature template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(
           Promise.resolve(false)
         );
@@ -237,7 +237,7 @@ describe(FeatureFlagDirective.name, () => {
         expect(featureEnabledElement).toBeFalsy();
       });
 
-      it('should render the fallback template', async () => {
+      it('render the fallback template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(
           Promise.resolve(false)
         );
@@ -253,7 +253,7 @@ describe(FeatureFlagDirective.name, () => {
     });
 
     describe('with Observable<boolean>', () => {
-      it('should not render the feature template', async () => {
+      it('not render the feature template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(of(false));
 
         fixture.detectChanges();
@@ -265,7 +265,7 @@ describe(FeatureFlagDirective.name, () => {
         expect(featureEnabledElement).toBeFalsy();
       });
 
-      it('should render the fallback template', async () => {
+      it('render the fallback template', async () => {
         featureFlagServiceMock.isEnabled.and.returnValue(of(false));
 
         fixture.detectChanges();

--- a/projects/core/src/feature-flag.directive.ts
+++ b/projects/core/src/feature-flag.directive.ts
@@ -10,7 +10,8 @@ import {
 
 import { Subject, takeUntil } from 'rxjs';
 
-import { FeatureFlag, FeatureFlagService } from './feature-flag.service';
+import { FeatureFlag } from './feature-flag';
+import { FeatureFlagService } from './feature-flag.service';
 import { FEATURE_FLAG_SERVICE } from './tokens';
 
 /**

--- a/projects/core/src/feature-flag.service.ts
+++ b/projects/core/src/feature-flag.service.ts
@@ -3,13 +3,7 @@ import { inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { NgxFlagrConfiguration } from './config';
-
-/**
- * A FeatureFlag can be a string or an array of strings representing one or more feature flags.
- *
- * @publicApi
- */
-export type FeatureFlag = string | string[];
+import { FeatureFlag } from './feature-flag';
 
 /**
  * Service responsible for retrieving feature flag information.

--- a/projects/core/src/feature-flag.spec.ts
+++ b/projects/core/src/feature-flag.spec.ts
@@ -1,0 +1,35 @@
+import { isFeatureFlag } from './feature-flag';
+
+describe('isFeatureFlag', () => {
+  it('should return true when passed a string', () => {
+    expect(isFeatureFlag('featureName')).toBeTrue();
+  });
+
+  it('should return true when passed an array of strings', () => {
+    expect(isFeatureFlag(['feature1', 'feature2'])).toBeTrue();
+  });
+
+  it('should return true when passed an empty array', () => {
+    expect(isFeatureFlag([])).toBeTrue();
+  });
+
+  it('should return false when passed a number', () => {
+    expect(isFeatureFlag(42)).toBeFalse();
+  });
+
+  it('should return false when passed a boolean', () => {
+    expect(isFeatureFlag(true)).toBeFalse();
+  });
+
+  it('should return false when passed an object', () => {
+    expect(isFeatureFlag({ featureName: true })).toBeFalse();
+  });
+
+  it('should return false when passed null', () => {
+    expect(isFeatureFlag(null)).toBeFalse();
+  });
+
+  it('should return false when passed undefined', () => {
+    expect(isFeatureFlag(undefined)).toBeFalse();
+  });
+});

--- a/projects/core/src/feature-flag.spec.ts
+++ b/projects/core/src/feature-flag.spec.ts
@@ -1,35 +1,35 @@
 import { isFeatureFlag } from './feature-flag';
 
 describe('isFeatureFlag', () => {
-  it('should return true when passed a string', () => {
+  it('return true when passed a string', () => {
     expect(isFeatureFlag('featureName')).toBeTrue();
   });
 
-  it('should return true when passed an array of strings', () => {
+  it('return true when passed an array of strings', () => {
     expect(isFeatureFlag(['feature1', 'feature2'])).toBeTrue();
   });
 
-  it('should return true when passed an empty array', () => {
+  it('return true when passed an empty array', () => {
     expect(isFeatureFlag([])).toBeTrue();
   });
 
-  it('should return false when passed a number', () => {
+  it('return false when passed a number', () => {
     expect(isFeatureFlag(42)).toBeFalse();
   });
 
-  it('should return false when passed a boolean', () => {
+  it('return false when passed a boolean', () => {
     expect(isFeatureFlag(true)).toBeFalse();
   });
 
-  it('should return false when passed an object', () => {
+  it('return false when passed an object', () => {
     expect(isFeatureFlag({ featureName: true })).toBeFalse();
   });
 
-  it('should return false when passed null', () => {
+  it('return false when passed null', () => {
     expect(isFeatureFlag(null)).toBeFalse();
   });
 
-  it('should return false when passed undefined', () => {
+  it('return false when passed undefined', () => {
     expect(isFeatureFlag(undefined)).toBeFalse();
   });
 });

--- a/projects/core/src/feature-flag.ts
+++ b/projects/core/src/feature-flag.ts
@@ -1,0 +1,18 @@
+/**
+ * A FeatureFlag can be a string or an array of strings representing one or more feature flags.
+ *
+ * @publicApi
+ */
+export type FeatureFlag = string | string[];
+
+/**
+ * Checks if the provided value is a FeatureFlag or not.
+ * @param {unknown} featureFlag - The value to be checked.
+ * @returns {featureFlag is FeatureFlag} - True if the provided value is a FeatureFlag, false otherwise.
+ */
+export const isFeatureFlag = (
+  featureFlag: unknown
+): featureFlag is FeatureFlag =>
+  typeof featureFlag === 'string' ||
+  (Array.isArray(featureFlag) &&
+    featureFlag.every(flag => typeof flag === 'string'));

--- a/projects/core/src/index.ts
+++ b/projects/core/src/index.ts
@@ -1,4 +1,5 @@
+export { FeatureFlag } from './feature-flag';
 export { FeatureFlagDirective } from './feature-flag.directive';
-export { FeatureFlag, FeatureFlagService } from './feature-flag.service';
+export { FeatureFlagService } from './feature-flag.service';
 export { provideNgxFlagr } from './provide-ngx-flagr';
 export { FEATURE_FLAG_SERVICE } from './tokens';

--- a/projects/core/src/provide-ngx-flagr.ts
+++ b/projects/core/src/provide-ngx-flagr.ts
@@ -1,12 +1,12 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 
+import { createConfiguration, NgxFlagrOptions } from './config';
 import { FeatureFlagDirective } from './feature-flag.directive';
 import { createFeatureFlagService } from './feature-flag.service';
-import { createConfiguration, NgxFlagrOptions } from './config';
 import {
-  INITIAL_CONFIGURATION,
   CONFIGURATION,
   FEATURE_FLAG_SERVICE,
+  INITIAL_CONFIGURATION,
 } from './tokens';
 
 /**


### PR DESCRIPTION
## Pull Request Description

This PR adds a new `canMatchFeatureFlag` guard method which can be used to protect routes based on their feature flags provided in `data`.

The behavior of the guard can be configured through the options in `NgxFlagrConfiguration.routing`:

- `keys`: the keys under which the feature flags details in the Angular Route `data` are
- `redirectToIfDisabled`: an optional URL to redirect to if the resolution fails
- `validIfNone`: defines if the guard should grant access to the route if no feature flags are provided

## Related Issue

Closes #3 

## Changes Made

- Implemented the `canMatchFeatureFlag` guard method

- Separate the `FeatureFlag` type in its own file
- Add a method to check if a value is a `FeatureFlag`
- Add tests for the `isFeatureFlag` method

- Add the configuration flags
- Add tests for the `createConfiguration`

## Checklist

- [x] I have updated the documentation.
- [x] My changes are tested and working as expected.
- [x] I have updated the relevant tests.
- [x] I have updated the version number (if applicable).
- [x] I have added my changes to the CHANGELOG.md file (if applicable).
- [x] My code follows the code style of this project.

## Additional Information

This PR also modifies the `provideNgxFlagr` method to pass the associated configuration
