### PR TITLE
10 configure the library with `NgxFlagrModule.forRoot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this project will be documented in this file.
 
 ### Feature
 
+- **core:** Added `NgxFlagrModule` module for configuring and providing `ngx-flagr`
+- **core:** Added `forRoot` static method to `NgxFlagrModule` for providing configuration options
 - **core:** create a functional guard `canMatchFeatureFlag`
 - **core:** add the configuration of the `canMatchFeatureFlag` behavior to the `NgxFlagrConfiguration`
 - **core:** update the usage of `provideNgxConfiguration` to include a default `routing` section

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ With `ngx-flagr`, you can easily manage feature flags, target specific users or 
     - [Configuration](#configuration)
     - [With feature flags](#with-feature-flags)
     - [With a fallback route](#with-a-fallback-route)
-    - [With a passthrough](#with-a-passthrough)
+    - [As a passthrough when no flags are provided](#as-a-passthrough-when-no-flags-are-provided)
     - [With a global redirection target](#with-a-global-redirection-target)
 - [License](#license)
 
@@ -52,7 +52,8 @@ export class CustomFeatureFlagService implements FeatureFlagService {
 
 ### Register the service
 
-Then, in your Angular `main.ts` file, configure the library to use this service:
+Then, in your Angular `main.ts` file, configure the library to use this service
+by calling `provideNgxFlagr` and passing in the desired options:
 
 ```ts
 import { bootstrapApplication } from '@angular/platform-browser';
@@ -65,6 +66,23 @@ import { FeatureFlagService } from './app/custom-feature-flag.service';
 bootstrapApplication(AppComponent, {
   providers: [
     provideNgxFlagr({ featureFlagService: CustomFeatureFlagService })
+  ],
+});
+```
+
+Alternatively, you can also use the `NgxFlagrModule.forRoot` static method:
+
+```ts
+import { bootstrapApplication } from '@angular/platform-browser';
+
+import { NgxFlagrModule } from '@ngx-flagr/core';
+
+import { AppComponent } from './app/app.component';
+import { FeatureFlagService } from './app/custom-feature-flag.service';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    NgxFlagrModule.forRoot({ featureFlagService: CustomFeatureFlagService })
   ],
 });
 ```

--- a/projects/core/src/feature-flag.module.ts
+++ b/projects/core/src/feature-flag.module.ts
@@ -1,0 +1,33 @@
+import { ModuleWithProviders, NgModule } from '@angular/core';
+
+import { NgxFlagrOptions } from './config';
+import { provideNgxFlagr } from './provide-ngx-flagr';
+
+/**
+ * The main module for configuring and providing the `ngx-flagr`
+ *
+ * Use the static `forRoot` method to provide the configuration options for the
+ * guard. This method also provides the directives and services associated with
+ * this library.
+ *
+ * @example
+ * ```
+ * imports: [
+ *   FeatureFlagModule.forRoot({
+ *       featureFlagService: CustomFeatureFlagService,
+ *     },
+ *   }),
+ * ]
+ * ```
+ */
+@NgModule({})
+export class FeatureFlagModule {
+  static forRoot(
+    options: NgxFlagrOptions
+  ): ModuleWithProviders<FeatureFlagModule> {
+    return {
+      ngModule: FeatureFlagModule,
+      providers: [provideNgxFlagr(options)],
+    };
+  }
+}

--- a/projects/core/src/ngx-flagr.module.spec.ts
+++ b/projects/core/src/ngx-flagr.module.spec.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { FeatureFlagDirective } from './feature-flag.directive';
+import { NgxFlagrModule } from './ngx-flagr.module';
+import { FeatureFlagService } from './feature-flag.service';
+import { FEATURE_FLAG_SERVICE } from './tokens';
+
+@Injectable()
+class TestFeatureFlagService implements FeatureFlagService {
+  isEnabled(): boolean {
+    return true;
+  }
+}
+
+describe(NgxFlagrModule.name, () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxFlagrModule],
+      providers: [TestFeatureFlagService],
+    });
+  });
+
+  it('does not provide the FeatureFlag directive', () => {
+    expect(() => TestBed.inject(FeatureFlagDirective)).toThrowError(
+      /No provider for FeatureFlagDirective/
+    );
+  });
+});
+
+describe('NgxFlagrModule.forRoot()', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NgxFlagrModule.forRoot({
+          featureFlagService: TestFeatureFlagService,
+        }),
+      ],
+      providers: [TestFeatureFlagService],
+    });
+  });
+
+  it('provides the FeatureFlag directive', () => {
+    expect(() => TestBed.inject(FeatureFlagDirective)).not.toThrowError(
+      /No provider for FeatureFlagDirective/
+    );
+  });
+
+  it('provides the desired service', () => {
+    expect(TestBed.inject(FEATURE_FLAG_SERVICE)).toBeInstanceOf(
+      TestFeatureFlagService
+    );
+  });
+});

--- a/projects/core/src/ngx-flagr.module.ts
+++ b/projects/core/src/ngx-flagr.module.ts
@@ -1,4 +1,5 @@
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule, Type } from '@angular/core';
+import { FeatureFlagService } from 'dist/@ngx-flagr/core';
 
 import { NgxFlagrOptions } from './config';
 import { provideNgxFlagr } from './provide-ngx-flagr';
@@ -21,12 +22,12 @@ import { provideNgxFlagr } from './provide-ngx-flagr';
  * ```
  */
 @NgModule({})
-export class FeatureFlagModule {
+export class NgxFlagrModule {
   static forRoot(
     options: NgxFlagrOptions
-  ): ModuleWithProviders<FeatureFlagModule> {
+  ): ModuleWithProviders<NgxFlagrModule> {
     return {
-      ngModule: FeatureFlagModule,
+      ngModule: NgxFlagrModule,
       providers: [provideNgxFlagr(options)],
     };
   }

--- a/projects/core/src/provide-ngx-flagr.spec.ts
+++ b/projects/core/src/provide-ngx-flagr.spec.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { FeatureFlagDirective } from './feature-flag.directive';
+import { FeatureFlagService } from './feature-flag.service';
+import { provideNgxFlagr } from './provide-ngx-flagr';
+import { FEATURE_FLAG_SERVICE } from './tokens';
+
+@Injectable()
+class TestFeatureFlagService implements FeatureFlagService {
+  isEnabled(): boolean {
+    return true;
+  }
+}
+
+describe(provideNgxFlagr.name, () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TestFeatureFlagService,
+        provideNgxFlagr({
+          featureFlagService: TestFeatureFlagService,
+        }),
+      ],
+    });
+  });
+
+  it('provides the FeatureFlag directive', () => {
+    expect(() => TestBed.inject(FeatureFlagDirective)).not.toThrowError(
+      /No provider for FeatureFlagDirective/
+    );
+  });
+
+  it('provides the desired service', () => {
+    expect(TestBed.inject(FEATURE_FLAG_SERVICE)).toBeInstanceOf(
+      TestFeatureFlagService
+    );
+  });
+});


### PR DESCRIPTION
## Pull Request Description

Add the `NgxFlagrModule.forRoot` static method to configure the library

## Related Issue

Closes #10 

## Changes Made

Create an `NgxFlagrModule` and a `forRoot` static method that configures the library

## Checklist

- [x] I have updated the documentation.
- [x] My changes are tested and working as expected.
- [x] I have updated the relevant tests.
- [x] I have updated the version number (if applicable).
- [x] I have added my changes to the CHANGELOG.md file (if applicable).
- [x] My code follows the code style of this project.
