### PR TITLE
Build on the CI to a non-ingored folder

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build website
-        run: npm run build
+        run: npm run build:ci
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
@@ -37,7 +37,7 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./build
+          publish_dir: ./prod-build
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212

--- a/apps/docs-app/package.json
+++ b/apps/docs-app/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "build:ci": "docusaurus build --out-dir prod-build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## Pull Request Description

The `build` folder in which the docusaurus website is created is ignored, resulting in the `gh-pages` branche only containing the `.no-jekyll` file

This PR builds the website to `prod-build` in the actions so that the assets will not be ignored and successfully published.