### PR TITLE
Only run the CI when a change is made in projects/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'projects/**'
   pull_request:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Others
+
+- **meta:** add a condition to run the CI only when something in `projects/` has changed
+
 ## [15.0.0-beta.1] - (2023-05-09)
 
 ### Bug Fixes


### PR DESCRIPTION
## Pull Request Description

Add a condition to run the CI only when something in `projects/` has changed

## Related Issue

Closes #19 

## Changes Made

Add a `path` for the GitHub Action's trigger

## Checklist

- [x] I have updated the documentation.
- [x] My changes are tested and working as expected.
- [x] I have updated the relevant tests.
- [x] I have updated the version number (if applicable).
- [x] I have added my changes to the CHANGELOG.md file (if applicable).
- [x] My code follows the code style of this project.
